### PR TITLE
Pre-install pulpcore-selinux in acceptance tests

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -8,9 +8,16 @@ class { 'katello::repo':
 
 include pulpcore::repo
 
-package { 'policycoreutils':
-  ensure => installed,
+if $facts['os']['selinux']['enabled'] {
+  package { 'pulpcore-selinux':
+    ensure  => installed,
+    require => Class['pulpcore::repo'],
+  }
 }
+
+# package { 'policycoreutils':
+#  ensure => installed,
+# }
 
 if $facts['os']['release']['major'] == '8' {
   package { 'glibc-langpack-en':


### PR DESCRIPTION
Otherwise the test will fail idempotence in an selinux enabled
environment due to Puppet deciding selinux labels at the time of
catalogue compilation. Policycoreutils is also no longer installed
since it is implied by pulpcore-selinux.